### PR TITLE
Feature/django 16 backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 *.egg
 ve/
 layers.db
+.tox/

--- a/rest_framework_extras/tests/models.py
+++ b/rest_framework_extras/tests/models.py
@@ -5,12 +5,16 @@ class Bar(models.Model):
     pass
 
 
+class Foo(models.Model):
+    pass
+
+
 class Base(models.Model):
     editable_field = models.CharField(max_length=32)
     another_editable_field = models.CharField(max_length=32)
     non_editable_field = models.CharField(max_length=32, editable=False)
     foreign_field = models.ForeignKey(
-        Bar,
+        Foo,
     )
     many_field = models.ManyToManyField(Bar)
 

--- a/rest_framework_extras/tests/requirements/16.txt
+++ b/rest_framework_extras/tests/requirements/16.txt
@@ -1,0 +1,3 @@
+Django==1.6.11
+djangorestframework==3.2.5
+six==1.9.0

--- a/rest_framework_extras/tests/settings/16.py
+++ b/rest_framework_extras/tests/settings/16.py
@@ -1,0 +1,66 @@
+import os
+
+
+USE_TZ = True
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "drfe.db",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    }
+}
+
+INSTALLED_APPS = (
+    # Include tests because it declares models
+    "rest_framework_extras.tests",
+    "rest_framework_extras",
+    "rest_framework",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.sites",
+)
+
+ROOT_URLCONF = "rest_framework_extras.tests.urls"
+
+MIDDLEWARE_CLASSES = (
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    "django.contrib.auth.context_processors.auth",
+    "django.template.context_processors.debug",
+    "django.template.context_processors.i18n",
+    "django.template.context_processors.media",
+    "django.template.context_processors.static",
+    "django.template.context_processors.tz",
+    "django.template.context_processors.request",
+    "django.contrib.messages.context_processors.messages",
+)
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
+        ],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": TEMPLATE_CONTEXT_PROCESSORS,
+        },
+    },
+]
+
+SITE_ID = 1
+
+STATIC_URL = "/static/"
+
+SECRET_KEY = "SECRET_KEY"
+
+DEBUG = True

--- a/rest_framework_extras/tests/test_views.py
+++ b/rest_framework_extras/tests/test_views.py
@@ -18,7 +18,7 @@ def get_control(model="vanilla", pk=1, another_editable_field_suffix=""):
         u"another_editable_field": u"another_editable_field%s" \
             % another_editable_field_suffix,
         u"many_field": [u"http://testserver/tests-bar/1/"],
-        u"foreign_field": u"http://testserver/tests-bar/1/",
+        u"foreign_field": u"http://testserver/tests-foo/1/",
         u"non_editable_field": u""
      }
 
@@ -42,11 +42,12 @@ class ViewsTestCase(unittest.TestCase):
         cls.client.login(username="editor", password="password")
 
         cls.bar = models.Bar.objects.create()
+        cls.foo = models.Foo.objects.create()
 
         cls.vanilla = models.Vanilla.objects.create(
             editable_field="editable_field",
             another_editable_field="another_editable_field",
-            foreign_field=cls.bar
+            foreign_field=cls.foo
         )
         cls.vanilla.many_field = [cls.bar]
         cls.vanilla.save()
@@ -54,7 +55,7 @@ class ViewsTestCase(unittest.TestCase):
         cls.with_form = models.WithForm.objects.create(
             editable_field="editable_field",
             another_editable_field="another_editable_field",
-            foreign_field=cls.bar
+            foreign_field=cls.foo
         )
         cls.with_form.many_field = [cls.bar]
         cls.with_form.save()
@@ -62,7 +63,7 @@ class ViewsTestCase(unittest.TestCase):
         cls.with_tricky_form = models.WithTrickyForm.objects.create(
             editable_field="editable_field",
             another_editable_field="another_editable_field",
-            foreign_field=cls.bar
+            foreign_field=cls.foo
         )
         cls.with_tricky_form.many_field = [cls.bar]
         cls.with_tricky_form.save()
@@ -82,7 +83,7 @@ class ViewsTestCase(unittest.TestCase):
         data = {
             "editable_field": "editable_field",
             "another_editable_field": "another_editable_field",
-            "foreign_field": "http://testserver/tests-bar/1/",
+            "foreign_field": "http://testserver/tests-foo/1/",
             "many_field": ["http://testserver/tests-bar/1/"],
         }
         response = self.client.post("/tests-vanilla/", data)
@@ -120,7 +121,7 @@ class ViewsTestCase(unittest.TestCase):
         data = {
             "editable_field": "editable_field",
             "another_editable_field": "another_editable_field",
-            "foreign_field": "http://testserver/tests-bar/1/",
+            "foreign_field": "http://testserver/tests-foo/1/",
             "many_field": ["http://testserver/tests-bar/1/"],
         }
         response = self.client.post("/tests-withform/", data)
@@ -154,7 +155,7 @@ class ViewsTestCase(unittest.TestCase):
         data = {
             "editable_field": "editable_field",
             "another_editable_field": "another_editable_field",
-            "foreign_field": "http://testserver/tests-bar/1/",
+            "foreign_field": "http://testserver/tests-foo/1/",
             "many_field": ["http://testserver/tests-bar/1/"],
             "an_integer": 777,
         }

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,14 @@
 [tox]
 envlist =
+    django16
     django19
 
 [testenv]
 basepython = python2.7
+
+[testenv:django16]
+deps = -rrest_framework_extras/tests/requirements/16.txt
+commands = python manage.py test rest_framework_extras.tests --settings=rest_framework_extras.tests.settings.16
 
 [testenv:django19]
 deps = -rrest_framework_extras/tests/requirements/19.txt


### PR DESCRIPTION
* Copied 1.9 test env to 1.6
* Django-rest-framework version dropped to 3.2.5 (As per Telkom) for 1.6
* Removed session authentication middleware for 1.6
* Reworked tests so foreignkey and m2m fields refer to different classes.
* Ignore .tox dir